### PR TITLE
Made Proc::Daemon internally taint safe by untainting pids read from any external source.

### DIFF
--- a/lib/Proc/Daemon.pod
+++ b/lib/Proc/Daemon.pod
@@ -391,7 +391,7 @@ the C<Proc::ProcessTable> module to be installed.
 
 C<Proc::Daemon::init> is still available for backwards capability.
 
-
+Proc::Daemon is now taint safe (assuming it is not passed any tainted parameters).
 
 
 =head1 AUTHORS

--- a/t/02_testmodule.t
+++ b/t/02_testmodule.t
@@ -22,6 +22,7 @@ use Proc::Daemon;
 my $cwd = Cwd::cwd();
 chdir 't' if $cwd !~ m{/t$};
 $cwd = Cwd::cwd();
+$cwd = ($cwd =~ /^(.*)$/)[0]; # untaint (needed for 03_taintmode)
 
 
 # create object

--- a/t/03_taintmode.t
+++ b/t/03_taintmode.t
@@ -1,0 +1,20 @@
+#!/usr/bin/perl -T
+
+use strict;
+use warnings;
+
+use Cwd;
+
+# blindly untaint PATH (since there's no way we can know what is safe)
+# hopefully anyone using Proc::Daemon in taint mode will set PATH more carefully
+local $ENV{'PATH'} = join ':', $ENV{'PATH'} =~ /([^:]+)/g;
+delete @ENV{'IFS', 'CDPATH', 'ENV', 'BASH_ENV'};
+
+# Try to make sure we are in the test directory
+my $cwd = Cwd::cwd();
+chdir 't' if $cwd !~ m{/t$};
+$cwd = Cwd::cwd();
+$cwd = ($cwd =~ /^(.*)$/)[0]; # untaint
+
+# re-run 02_testmodule.t with taint mode on
+require "$cwd/02_testmodule.t";


### PR DESCRIPTION
Also, added a new test which re-runs the primary 02_testmodule.t in taint mode. (I only tested on linux so hopefully this works in non-unix environments like Win32).

I added a comment in the pod to indicate that Proc::Daemon is now taint safe if not passed any tainted parameters.  That is to say that Proc::Daemon will no longer be the source of any tainted data, particularly from get_pid (as it used to).  However, since it uses commands like 'chdir' and 'exec' internally, you might still get a fatal error in taint mode if you pass it tainted data.  That seems reasonable to me since Proc::Daemon has no safe way of untainting such data; it should therefore be the caller's responsibility.
