### PR TITLE
added option to setgid, same as setuid

### DIFF
--- a/lib/Proc/Daemon.pm
+++ b/lib/Proc/Daemon.pm
@@ -31,6 +31,7 @@ $Proc::Daemon::VERSION = '0.17';
 #
 #   %Daemon_Settings are hash key=>values and can be:
 #     work_dir     => '/working/daemon/directory'   -> defaults to '/'
+#     setgid       => 12345                         -> defaults to <undef>
 #     setuid       => 12345                         -> defaults to <undef>
 #     child_STDIN  => '/path/to/daemon/STDIN.file'  -> defautls to '</dev/null'
 #     child_STDOUT => '/path/to/daemon/STDOUT.file' -> defaults to '+>/dev/null'
@@ -227,6 +228,12 @@ sub Init {
                         else { $hc_fd = $_ if POSIX::close( $_ ) }
                     }
                 }
+
+                # Sets the real group identifier and the effective group
+                # identifier for the daemon process before opening files.
+                # Must set group first because you cannot change group
+                # once you have changed user
+                POSIX::setgid( $self->{setgid} ) if defined $self->{setgid};
 
                 # Sets the real user identifier and the effective user
                 # identifier for the daemon process before opening files.

--- a/lib/Proc/Daemon.pod
+++ b/lib/Proc/Daemon.pod
@@ -150,6 +150,13 @@ stay the same. It is helpful to define the argument C<setuid> if you start your
 script at boot time by init with the superuser, but wants the daemon to run
 under a normal user account.
 
+=item setgid
+
+Sets the real group identifier (C<$(>) and the effective group identifier
+(C<$)>) for the daemon process using C<POSXI::setgid( ... )>, just like
+C<setuid>.  As with C<setuid>, the first user must have the rights to switch to the
+new group, otherwise the group id will not be changed.
+
 
 =item child_STDIN
 

--- a/t/02_testmodule.t
+++ b/t/02_testmodule.t
@@ -85,6 +85,9 @@ exit;";
             if ( ok( -e "$cwd/kid.pl", "child_1 has created the 'kid.pl' file" ) ) {
                 my $Kid_PID2 = $daemon->Init( { 
                     exec_command => "perl $cwd/kid.pl",
+                    # this is essentially a noop but gives us better test coverage
+                    setgid => (split / /, $))[0],
+                    setuid => $>,
                 } );
 
                 if ( ok( $Kid_PID2, "child_2 was created with PID: " . ( defined $Kid_PID2 ? $Kid_PID2 : '<undef>' ) ) ) {


### PR DESCRIPTION
Adding the code to support setgid was pretty trivial.  However, finding a portable way to test that functionality is not trivial.  As it was, the exisitng setuid feature was untested so I had hoped to add a test for both features.

I considered using the nobody/nogroup pair but that creates two problems.  The first problem is that the 'nobody' user likely doesn't exist on platforms such as Win32.  The second problem is that the 'nobody' user very likely can't write to the t/ test directory (as the other tests do to allow communication between the spawned daemons). I could use File::Spec->tmpdir to get a more portable temp path that is likely world writable but that still doesn't guarantee the 'nobody' user will exist or will be able to write to that path.

In the end, the only test I was reasonably sure would work cross platform was to just setgid and setuid back to the current effective group/user.  That is basically a noop but at least it provides a tiny improvement in test coverage :(.

Let me know if you can think of a better way to test this.
