### PR TITLE
PRC - Add 'use warnings'

### DIFF
--- a/lib/Proc/Daemon.pm
+++ b/lib/Proc/Daemon.pm
@@ -20,6 +20,7 @@
 package Proc::Daemon;
 
 use strict;
+use warnings;
 use POSIX();
 
 $Proc::Daemon::VERSION = '0.23';


### PR DESCRIPTION
Solve one of CPANTS warnings about missing 'use warnings'.
I've tested the change in Ubuntu perl 5.22, with no impact from the 'use warnings' statement.
